### PR TITLE
Featrue/member pagination

### DIFF
--- a/poj/src/main/java/com/poj/controller/admin/AdminController.java
+++ b/poj/src/main/java/com/poj/controller/admin/AdminController.java
@@ -1,21 +1,39 @@
 package com.poj.controller.admin;
 
+import com.poj.dto.member.BasicMemberDto;
+import com.poj.entity.member.Authority;
+import com.poj.entity.member.EAuthority;
+import com.poj.repository.member.AuthorityRepository;
+import com.poj.repository.member.MemberRepository;
 import com.poj.service.admin.AdminService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
+    private final MemberRepository memberRepository;
+
     @GetMapping("/confirm")
-    public ResponseEntity<String> confirm(@RequestParam Long memberId){
+    public ResponseEntity<String> confirm(@RequestParam Long memberId) {
         adminService.upgradeToUser(memberId);
         return ResponseEntity.ok("success");
+    }
+
+    @GetMapping("/members")
+    public ResponseEntity<Page<BasicMemberDto>> members(
+            @RequestParam(required = false) EAuthority authority,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(memberRepository.findAllByAuthority(authority, page, size));
     }
 }

--- a/poj/src/main/java/com/poj/dto/member/BasicMemberDto.java
+++ b/poj/src/main/java/com/poj/dto/member/BasicMemberDto.java
@@ -1,0 +1,19 @@
+package com.poj.dto.member;
+
+import com.poj.entity.member.EAuthority;
+import com.poj.entity.member.Member;
+import com.poj.util.AuthorityUtil;
+import lombok.Data;
+
+@Data
+public class BasicMemberDto {
+    private String username;
+    private String email;
+    private EAuthority authority;
+
+    public BasicMemberDto(Member member) {
+        this.username = member.getUsername();
+        this.email = member.getEmail();
+        this.authority = AuthorityUtil.getAuthority(member);
+    }
+}

--- a/poj/src/main/java/com/poj/entity/member/Authority.java
+++ b/poj/src/main/java/com/poj/entity/member/Authority.java
@@ -15,12 +15,12 @@ public class Authority {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    private EAuthority name;
+    private EAuthority eAuthority;
 
     public String getName() {
-        return name.name();
+        return eAuthority.name();
     }
-    public Authority(EAuthority name) {
-        this.name = name;
+    public Authority(EAuthority eAuthority) {
+        this.eAuthority = eAuthority;
     }
 }

--- a/poj/src/main/java/com/poj/entity/member/EAuthority.java
+++ b/poj/src/main/java/com/poj/entity/member/EAuthority.java
@@ -1,5 +1,12 @@
 package com.poj.entity.member;
 
 public enum EAuthority {
-    ROLE_ADMIN, ROLE_USER, ROLE_UNVERIFIED
+    ROLE_UNVERIFIED, ROLE_USER, ROLE_ADMIN;
+
+    // ROLE_UNVERIFIED: 1, ROLE_USER: 2, ROLE_ADMIN: 3
+    // 이는 member 의 authorities 의 개수와도 같습니다.
+    // 예를 들어 ROLE_ADIMIN 의 경우 모든 권한을 보유하므로 authorities 의 개수가 3개입니다.
+    public int getLevel() {
+        return this.ordinal()+1;
+    }
 }

--- a/poj/src/main/java/com/poj/factory/member/MemberFactory.java
+++ b/poj/src/main/java/com/poj/factory/member/MemberFactory.java
@@ -27,12 +27,39 @@ public class MemberFactory {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .authorities(Set.of(
-                        authorityRepository.findByName(EAuthority.ROLE_UNVERIFIED)))
+                        authorityRepository.findByEAuthority(EAuthority.ROLE_UNVERIFIED)))
                 .build();
         memberRepository.save(member);
         return member;
 
     }
 
+    public Member createUser(SignupRequest request) {
+        authValidator.signupValidate(request);
+        Member member = Member.builder()
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .authorities(Set.of(
+                        authorityRepository.findByEAuthority(EAuthority.ROLE_UNVERIFIED),
+                        authorityRepository.findByEAuthority(EAuthority.ROLE_USER)))
+                .build();
+        memberRepository.save(member);
+        return member;
+    }
 
+    public Member createAdmin(SignupRequest request) {
+        authValidator.signupValidate(request);
+        Member member = Member.builder()
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .authorities(Set.of(
+                        authorityRepository.findByEAuthority(EAuthority.ROLE_UNVERIFIED),
+                        authorityRepository.findByEAuthority(EAuthority.ROLE_USER),
+                        authorityRepository.findByEAuthority(EAuthority.ROLE_ADMIN)))
+                .build();
+        memberRepository.save(member);
+        return member;
+    }
 }

--- a/poj/src/main/java/com/poj/repository/member/AuthorityRepository.java
+++ b/poj/src/main/java/com/poj/repository/member/AuthorityRepository.java
@@ -3,9 +3,9 @@ package com.poj.repository.member;
 import com.poj.entity.member.Authority;
 import com.poj.entity.member.EAuthority;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AuthorityRepository extends JpaRepository<Authority, Long> {
-    Authority findByName(EAuthority name);
+    @Query("select a from Authority a where a.eAuthority = :eAuthority")
+    Authority findByEAuthority(EAuthority eAuthority);
 }

--- a/poj/src/main/java/com/poj/repository/member/MemberRepositoryQuerydsl.java
+++ b/poj/src/main/java/com/poj/repository/member/MemberRepositoryQuerydsl.java
@@ -1,11 +1,16 @@
 package com.poj.repository.member;
 
 
+import com.poj.dto.member.BasicMemberDto;
+import com.poj.entity.member.Authority;
+import com.poj.entity.member.EAuthority;
 import com.poj.entity.member.Member;
+import org.springframework.data.domain.Page;
 
 import java.util.Optional;
 
 public interface MemberRepositoryQuerydsl {
     Optional<Member> findByEmailWithAuthorities(String email);
     Optional<Member> findByIdWithAuthorities(Long id);
+    Page<BasicMemberDto> findAllByAuthority(EAuthority authority, int page, int size);
 }

--- a/poj/src/main/java/com/poj/repository/member/MemberRepositoryQuerydslImpl.java
+++ b/poj/src/main/java/com/poj/repository/member/MemberRepositoryQuerydslImpl.java
@@ -1,10 +1,16 @@
 package com.poj.repository.member;
 
+import com.poj.dto.member.BasicMemberDto;
+import com.poj.entity.member.Authority;
+import com.poj.entity.member.EAuthority;
 import com.poj.entity.member.Member;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.poj.entity.member.QMember.*;
@@ -35,5 +41,30 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl{
                         .where(member.id.eq(id))
                         .fetchFirst()
         );
+    }
+
+    @Override
+    public Page<BasicMemberDto> findAllByAuthority(EAuthority authority, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
+        List<Member> content = query
+                .selectFrom(member)
+                .leftJoin(member.authorities).fetchJoin()
+                .where(authorityFilter(authority))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(member.createdAt.asc())
+                .fetch();
+        List<BasicMemberDto> dtoContent =
+                content.stream().map(BasicMemberDto::new).toList();
+        int totalCount = query.selectFrom(member).where(authorityFilter(authority)).fetch().size();
+
+        return new PageImpl<>(dtoContent, pageable, totalCount);
+    }
+
+    private BooleanBuilder authorityFilter(EAuthority authority) {
+        if (authority == null) {
+            return null;
+        }
+        return new BooleanBuilder(member.authorities.size().eq(authority.getLevel()));
     }
 }

--- a/poj/src/main/java/com/poj/service/admin/AdminService.java
+++ b/poj/src/main/java/com/poj/service/admin/AdminService.java
@@ -20,6 +20,6 @@ public class AdminService {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new IllegalArgumentException("해당 회원이 존재하지 않습니다.")
         );
-        member.getAuthorities().add(authorityRepository.findByName(EAuthority.ROLE_USER));
+        member.getAuthorities().add(authorityRepository.findByEAuthority(EAuthority.ROLE_USER));
     }
 }

--- a/poj/src/main/java/com/poj/util/AuthorityUtil.java
+++ b/poj/src/main/java/com/poj/util/AuthorityUtil.java
@@ -1,0 +1,26 @@
+package com.poj.util;
+
+import com.poj.entity.member.EAuthority;
+import com.poj.entity.member.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthorityUtil {
+    public static EAuthority getAuthority(Member member) {
+        if (member.getAuthorities().isEmpty()) {
+            throw new IllegalStateException("유저의 권한이 존재하지 않습니다");
+        }
+        if (member.getAuthorities().stream().anyMatch(authority -> Objects.equals(authority.getName(), EAuthority.ROLE_ADMIN.name()))) {
+            return EAuthority.ROLE_ADMIN;
+        } else if (member.getAuthorities().stream().anyMatch(authority -> Objects.equals(authority.getName(), EAuthority.ROLE_USER.name()))) {
+            return EAuthority.ROLE_USER;
+        } else if (member.getAuthorities().stream().anyMatch(authority -> Objects.equals(authority.getName(), EAuthority.ROLE_UNVERIFIED.name()))) {
+            return EAuthority.ROLE_UNVERIFIED;
+        } else {
+            throw new IllegalStateException("적절한 권한이 존재하지 않습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## ⭐Key Changes
1. 멤버를 권한 별로 오프셋 기반 페이지네이션을 사용해서 조회할 수 있습니다. 이때 정렬 조건은 회원 생성 날짜가 빠른 순 입니다.
2. 권한이 주어지지 않는다면 모든 멤버를 페이지네이션으로 조회합니다.

## 📌 issue
close #20 

